### PR TITLE
Add the annotate gem to the development group for annotating classes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ group :development, :test do
 end
 
 group :development do
+  # Annotate Rails classes with schema and routes info
+  gem 'annotate', '~> 2.6.5'
   gem 'listen', '>= 3.0.5', '< 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.1, >= 2.1.4)
+    annotate (2.6.5)
+      activerecord (>= 2.3.0)
+      rake (>= 0.8.7)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -148,6 +151,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate (~> 2.6.5)
   bootsnap (>= 1.4.2)
   byebug
   listen (>= 3.0.5, < 3.2)

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,30 @@
+if Rails.env.development?
+  task :set_annotation_options do
+    Annotate.set_defaults({
+      'position_in_routes'   => 'before',
+      'position_in_class'    => 'before',
+      'position_in_test'     => 'before',
+      'position_in_fixture'  => 'before',
+      'position_in_factory'  => 'before',
+      'show_indexes'         => 'false',
+      'simple_indexes'       => 'false',
+      'model_dir'            => 'app/models',
+      'include_version'      => 'false',
+      'require'              => '',
+      'exclude_tests'        => 'false',
+      'exclude_fixtures'     => 'false',
+      'exclude_factories'    => 'false',
+      'ignore_model_sub_dir' => 'false',
+      'skip_on_db_migrate'   => 'false',
+      'format_bare'          => 'true',
+      'format_rdoc'          => 'false',
+      'format_markdown'      => 'false',
+      'sort'                 => 'false',
+      'force'                => 'false',
+      'trace'                => 'false',
+      'hide_default_column_types' => 'text'
+    })
+  end
+
+  Annotate.load_tasks
+end


### PR DESCRIPTION
Add the annotate [gem](https://github.com/ctran/annotate_models), which adds schema documentation comments to the top of each: 

- Active Record models
- Fixture files
- Tests and Specs
- Thoughtbot's factory_bot factories, i.e. the (spec|test)/factories/<model>_factory.rb files
- routes.rb file (for Rails projects)