### PR TITLE
Add bullet gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 # gem 'rack-cors'
 
 group :development, :test do
+  gem 'bullet', '~> 6.0.1'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
+    bullet (6.0.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.0.1)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
@@ -142,6 +145,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    uniform_notifier (1.12.1)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -153,6 +157,7 @@ PLATFORMS
 DEPENDENCIES
   annotate (~> 2.6.5)
   bootsnap (>= 1.4.2)
+  bullet (~> 6.0.1)
   byebug
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,4 +49,13 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = false
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+    Bullet.add_footer = true
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,10 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.raise = true 
+  end
 end


### PR DESCRIPTION
Watch queries on development or test environments and receive notifications when we should add eager loading or when we are using eager loading that is not necessary. 