### PR TITLE
Adds code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+*       @nbassagoda
+*       @fede-moya
+*       @cindy-a
+*       @diebas
+*       @diegokloop
+*       @mconiglio
+*       @mwolman
+*       @lucaleivaloop
+*       @donatoaguirre24
+*       @letiesperon
+*       @jferreira93
+*       @elestu
+*       @aperezcristina
+*       @ValeFranchi


### PR DESCRIPTION
Adds `.github` folder to store all future GitHub configurations and `CODEOWNERS` to tag all LoopStudio members involved in the maintenance of this template