### PR TITLE
Make rubocop run on other folders too

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,13 +4,16 @@ AllCops:
   Exclude:
     - vendor/**/*
     - .circleci/*
-    - 'db/**/*'
+    - db/schema.rb
+    - bin/bundle
 
 Documentation:
   Enabled: false
 
 Metrics/AbcSize:
   Max: 15
+  Exclude:
+    - db/migrate/*
 
 Metrics/BlockLength:
   CountComments: false
@@ -59,3 +62,6 @@ Style/ModuleFunction:
 LexicallyScopedActionFilter:
   Exclude:
       - app/controllers/**/**
+
+Rails/NotNullColumn:
+  Enabled: false

--- a/db/migrate/20190705213619_devise_token_auth_create_users.rb
+++ b/db/migrate/20190705213619_devise_token_auth_create_users.rb
@@ -1,26 +1,28 @@
 class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
   def change
-    add_column :users, :email, :string, null: false
-    add_column :users, :uid, :string, null: false, default: nil
-    add_column :users, :provider, :string, null: false, default: 'email'
-    add_column :users, :encrypted_password, :string, null: false, default: nil
-    add_column :users, :reset_password_token, :string
-    add_column :users, :reset_password_sent_at, :datetime
-    add_column :users, :remember_created_at, :datetime
-    add_column :users, :confirmation_token, :string
-    add_column :users, :confirmed_at, :datetime
-    add_column :users, :confirmation_sent_at, :datetime
-    add_column :users, :current_sign_in_at, :datetime
-    add_column :users, :last_sign_in_at, :datetime
-    add_column :users, :current_sign_in_ip, :string
-    add_column :users, :last_sign_in_ip, :string
-    add_column :users, :unconfirmed_email, :string
-    add_column :users, :sign_in_count, :integer, default: 0
-    add_column :users, :tokens, :json
-    add_column :users, :must_change_password, :boolean, default: false
+    change_table :users, bulk: true do |t|
+      t.string :provider, null: false, default: 'email'
+      t.string :email, null: false
+      t.string  :uid, null: false, default: nil
+      t.string  :encrypted_password, null: false, default: nil
+      t.string :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.datetime :remember_created_at
+      t.string :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+      t.string :unconfirmed_email
+      t.integer :sign_in_count, default: 0
+      t.json :tokens
+      t.boolean :must_change_password, default: false
+    end
 
     add_index :users, :email, unique: true
-    add_index :users, [:uid, :provider], unique: true
+    add_index :users, %i[uid provider], unique: true
     add_index :users, :reset_password_token, unique: true
     add_index :users, :confirmation_token, unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,9 +20,9 @@ ActiveRecord::Schema.define(version: 2019_07_05_213619) do
     t.string "last_name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "provider", default: "email", null: false
     t.string "email", null: false
     t.string "uid", null: false
-    t.string "provider", default: "email", null: false
     t.string "encrypted_password", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,4 @@
-# This file should contain all the record creation needed
-# to seed the database with its default values.
 # This is not the place for test data
-# The data can then be loaded with the rails db:seed command
+# DO NOT USE FOR TEST DATA
 # Separate the seeds in different Seed Service Objects
+# The data can then be loaded with the rails db:seed command

--- a/lib/tasks/analyze_code.rake
+++ b/lib/tasks/analyze_code.rake
@@ -1,4 +1,4 @@
 task :analyze_code do
-  sh 'bundle exec rubocop app config lib'
+  sh 'bundle exec rubocop app config lib spec db'
   sh 'bundle exec reek app config lib'
 end


### PR DESCRIPTION
## Make rubocop run on other folders too

#### Description:

Makes the necessary configuration/fixes so that we enforce styling on specs files and db folder too. 

---


#### :heavy_check_mark:Tasks:

* Changed the rubocop line in the code analyse task to also check the db and spec folder. 
* Excluded a path inside the db folder so that running `rubocop` in all the project throws no warnings.

---
