### PR TITLE
Add error message when response is nil

### DIFF
--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,5 +1,7 @@
 module RequestHelpers
   def json(response)
+    raise 'Response is nil. Are you sure you made a request?' unless response
+
     JSON.parse(response.body, symbolize_names: true)
   end
 


### PR DESCRIPTION
## Add error message when response is nil

#### Description:

Add a line to json helper method so it raises a helpful message when the response is nil.

