### PR TITLE
Modify ExceptionHandler to not catch exception on development

### DIFF
--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -14,7 +14,7 @@ module ExceptionHandler
   end
 
   def render_standard_error(exception)
-    raise exception if Rails.env.test?
+    raise exception if Rails.env.test? || Rails.env.development?
 
     logger.error(exception)
 


### PR DESCRIPTION
## Modify ExceptionHandler to not catch exceptions on development

#### Description:

I have recently started a new project with an exception handler very similar to this one and I found out that it is not useful to catch exceptions on development either. I think they should only be cached on production. 

---
