### PR TITLE
Modify validation error api responses

### DIFF
--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -30,7 +30,7 @@ module ExceptionHandler
   end
 
   def render_record_invalid(exception)
-    errors = exception.record.errors.full_messages
+    errors = exception.record.errors.messages
     render_errors(errors, :unprocessable_entity)
   end
 end

--- a/spec/requests/api/v1/auth/registrations/create_spec.rb
+++ b/spec/requests/api/v1/auth/registrations/create_spec.rb
@@ -64,7 +64,7 @@ describe 'POST api/v1/auth/registrations', type: :request do
 
       it 'returns an error message' do
         expect(json(subject)).to eq(
-          errors: ["First name can't be blank"]
+          errors: [{ first_name: ["can't be blank"] }]
         )
       end
     end
@@ -76,7 +76,7 @@ describe 'POST api/v1/auth/registrations', type: :request do
 
       it 'returns an error message' do
         expect(json(subject)).to eq(
-          errors: ["Last name can't be blank"]
+          errors: [{ last_name: ["can't be blank"] }]
         )
       end
     end
@@ -88,7 +88,7 @@ describe 'POST api/v1/auth/registrations', type: :request do
 
       it 'returns an error message' do
         expect(json(subject)).to eq(
-          errors: ["Email can't be blank"]
+          errors: [{ email: ["can't be blank"] }]
         )
       end
     end
@@ -100,7 +100,7 @@ describe 'POST api/v1/auth/registrations', type: :request do
 
       it 'returns an error message' do
         expect(json(subject)).to eq(
-          errors: ["Password can't be blank"]
+          errors: [{ password: ["can't be blank"] }]
         )
       end
     end


### PR DESCRIPTION
## Modify how the api is informing about record validation errors

#### :link: Board reference:

* [NameOnTheCard](linkToTheCard)

---

#### Description:

I believe this change would provide more flexibility to the clients to decide how to inform to the final user about the errors. The following are body examples of the responses of the api to requests that triggered record validation errors.  

### This is how it's currently working: 
```json
{
    "errors": [
        "Title can't be blank"
    ]
}
```
### This is how it's gonna work after the modification:
```json
{
    "errors": [
        {
            "title": [
                "can't be blank"
            ]
        }
    ]
}
```



---