### PR TITLE
Modify sign up params to be consistent with the rest

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -8,7 +8,7 @@ module Api
         private
 
         def sign_up_params
-          params.require(:user).permit(:email, :password, :first_name, :last_name)
+          params.permit(:email, :password, :first_name, :last_name)
         end
 
         def account_update_params

--- a/spec/requests/api/v1/auth/registrations/create_spec.rb
+++ b/spec/requests/api/v1/auth/registrations/create_spec.rb
@@ -10,13 +10,10 @@ describe 'POST api/v1/auth/registrations', type: :request do
   let(:password) { 'abcd1234' }
   let(:params) do
     {
-      user:
-        {
-          first_name: first_name,
-          last_name: last_name,
-          email: email,
-          password: password
-        }
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      password: password
     }
   end
 
@@ -54,7 +51,7 @@ describe 'POST api/v1/auth/registrations', type: :request do
     context 'when any required param is given' do
       let(:params) { {} }
 
-      it { is_expected.to have_http_status(:bad_request) }
+      it { is_expected.to have_http_status(:unprocessable_entity) }
     end
 
     context 'when the first_name is missing' do


### PR DESCRIPTION
## Modify sign up params to be consistent with the rest

#### :link: Board reference:

* [NameOnTheCard](linkToTheCard)

---

#### Description:

Right now the sign up endpoint is expecting to receive a body having this structure:
```
{
  user: {
    first_name: '',
    // ...
  }
}
```
But that's not being consistent with the update endpoint that expects something like this:
```
{
  first_name: '',
  // ...
}
```
So the idea is to unify the expected parameters structure to be the same as the update endpoint
