### PR TITLE
Modify api to not check content types of requests with empty bodies

### DIFF
--- a/app/controllers/concerns/act_as_api_request.rb
+++ b/app/controllers/concerns/act_as_api_request.rb
@@ -7,6 +7,7 @@ module ActAsApiRequest
   end
 
   def check_json_request
+    return if request_body.empty?
     return if request.content_type&.match?(/json/)
 
     render json: { error: I18n.t('errors.invalid_content_type') }, status: :bad_request
@@ -14,5 +15,11 @@ module ActAsApiRequest
 
   def skip_session_storage
     request.session_options[:skip] = true
+  end
+
+  private
+
+  def request_body
+    request.body.read
   end
 end


### PR DESCRIPTION
## Modify ActAsApiRequest concern

#### Description:

Currently all incoming requests need to have the Content-Type header set as application/json. This does not make lot of sense, since it's not necessary to specify the content type if the request has no body. 

This modification will allow request without the Content-Type header for those requests without body. 

---