### PR TITLE
Disable MissingSafeMethod on reek rules

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -45,7 +45,7 @@ detectors:
     enabled: true
     exclude: []
   MissingSafeMethod:
-    enabled: true
+    enabled: false
     exclude: []
   ModuleInitialize:
     enabled: true


### PR DESCRIPTION
## Disable MissingSafeMethod on reek rules

#### Description:

@mconiglio @lucaleivaloop and I believe that this rule makes sense when building gems or open source projects where you want to provide safe methods in addition to the unsafe(!) option, for interface usability purposes. Which it's not the case for general ruby classes under a rails project. 

---