### PR TITLE
Lower the concurrency on sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: 25
+:concurrency: 15
 :queues:
   - default
   - mailers


### PR DESCRIPTION
## TITLE

#### :link: Board reference:

* [Sidekiq concurrency is setup in 25!! A Heroku Redis free tier dyno can stand only 20](https://loopstudio.atlassian.net/jira/software/projects/API/boards/12?selectedIssue=API-60)

---

#### Description:

Lower the concurrency on Sidekiq to adjust the one allowed by a free Heroku dyno while leaving some room to other processes.

---

