### PR TITLE
Improve the code analyzer

### DIFF
--- a/lib/tasks/analyze_code.rake
+++ b/lib/tasks/analyze_code.rake
@@ -1,4 +1,16 @@
+require 'optparse'
+
 task :analyze_code do
-  sh 'bundle exec rubocop app config lib spec db'
-  sh 'bundle exec reek app config lib'
+  options = {}
+  OptionParser.new do |opts|
+    opts.on('-a') { |autofix| options[:autofix] = autofix }
+  end.parse!
+
+  files_diff = `git diff --diff-filter=ACMRTUXB --name-only origin/master... | \
+               xargs | sed "s/\\n/\\s/"`
+
+  if files_diff.present?
+    sh "bundle exec rubocop --force-exclusion #{'-a' if options[:autofix]} #{files_diff}"
+    sh "bundle exec reek --force-exclusion -c .reek.yml #{files_diff}"
+  end
 end


### PR DESCRIPTION
#### :link: Board reference:

* [Accept -a option in code analyzer task to auto fix rubocop](https://loopstudio.atlassian.net/jira/software/projects/API/boards/12?selectedIssue=API-53)

---

#### Description:

Improves the code analyzer by making it accept `-a` as a parameter and making it work on the diff instead of fixed folders.

---
