### PR TITLE
Fix annotate gem not working

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Metrics/BlockLength:
   Exclude:
     - config/**/*
     - spec/**/*
+    - lib/tasks/auto_annotate_models.rake
 
 Metrics/BlockNesting:
   Max: 4
@@ -72,6 +73,7 @@ LexicallyScopedActionFilter:
 Rails/RakeEnvironment:
   Exclude:
     - lib/tasks/linters.rake
+    - lib/tasks/auto_annotate_models.rake
 
 Rails/NotNullColumn:
   Enabled: false

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,28 +1,52 @@
 if Rails.env.development?
+  require 'annotate'
   task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
     Annotate.set_defaults(
+      'additional_file_patterns' => [],
+      'routes' => 'false',
+      'models' => 'true',
       'position_in_routes' => 'before',
       'position_in_class' => 'before',
       'position_in_test' => 'before',
       'position_in_fixture' => 'before',
       'position_in_factory' => 'before',
-      'show_indexes' => 'false',
-      'simple_indexes' => 'false',
+      'position_in_serializer' => 'before',
+      'show_foreign_keys' => 'true',
+      'show_complete_foreign_keys' => 'false',
+      'show_indexes' => 'true',
+      'simple_indexes' => 'true',
       'model_dir' => 'app/models',
+      'root_dir' => '',
       'include_version' => 'false',
       'require' => '',
       'exclude_tests' => 'false',
       'exclude_fixtures' => 'false',
       'exclude_factories' => 'false',
+      'exclude_serializers' => 'false',
+      'exclude_scaffolds' => 'true',
+      'exclude_controllers' => 'true',
+      'exclude_helpers' => 'true',
+      'exclude_sti_subclasses' => 'false',
       'ignore_model_sub_dir' => 'false',
+      'ignore_columns' => nil,
+      'ignore_routes' => nil,
+      'ignore_unknown_models' => 'false',
+      'hide_limit_column_types' => 'integer,bigint,boolean',
+      'hide_default_column_types' => 'json,jsonb,hstore,text',
       'skip_on_db_migrate' => 'false',
       'format_bare' => 'true',
       'format_rdoc' => 'false',
       'format_markdown' => 'false',
       'sort' => 'false',
       'force' => 'false',
+      'frozen' => 'false',
+      'classified_sort' => 'true',
       'trace' => 'false',
-      'hide_default_column_types' => 'text'
+      'wrapper_open' => nil,
+      'wrapper_close' => nil,
+      'with_comment' => 'true'
     )
   end
 


### PR DESCRIPTION
#### Fix annotate gem that was not annotating

#### Description:

Due to problem with Rails 6 stated here https://github.com/ctran/annotate_models/issues/689 the old version of the annotate install file made it not work correctly (it wasn't running when running the migrations)

---
