### PR TITLE
Improve error handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,3 +78,6 @@ Rails/RakeEnvironment:
 
 Rails/NotNullColumn:
   Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -13,6 +13,10 @@ module ExceptionHandler
     render json: { errors: error_messages }, status: status
   end
 
+  def render_attributes_errors(error_messages)
+    render json: { attributes_errors: error_messages }, status: :unprocessable_entity
+  end
+
   def render_standard_error(exception)
     raise exception if Rails.env.test?
 
@@ -31,7 +35,7 @@ module ExceptionHandler
 
   def render_record_invalid(exception)
     errors = exception.record.errors.messages
-    render_errors(errors, :unprocessable_entity)
+    render_attributes_errors(errors)
   end
 
   def set_raven_context

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,4 @@ class User < ApplicationRecord
 
   include DeviseTokenAuth::Concerns::User
   serialize :tokens
-
-  validates :email, presence: true, uniqueness: { case_sensitive: false, scope: :provider }
 end

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -63,7 +63,7 @@ describe 'POST /api/v1/users', type: :request do
       it 'returns an error message' do
         post_request
 
-        expect(json[:errors][0][:email]).not_to be_nil
+        expect(json[:attributes_errors][:email]).not_to be_nil
       end
     end
 
@@ -79,7 +79,7 @@ describe 'POST /api/v1/users', type: :request do
       it 'returns an error message' do
         post_request
 
-        expect(json[:errors][0][:password]).not_to be_nil
+        expect(json[:attributes_errors][:password]).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
## Improve API error rendering

#### Description:

Changes the key from "errors" to "attribute_errors" (for invalid records), removes repeated email validation and removes unnecessary [] array surrounding error hash. 

* Also makes gem not required to be ordered alphabetically on the gemfile anymore

---