### PR TITLE
Add mry gem to README.md

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ group :development do
   gem 'annotate', '~> 3.1.1'
   gem 'letter_opener', '~> 1.7.0'
   gem 'listen', '>= 3.0.5', '< 3.3'
-  gem 'mry'
   gem 'reek', '~> 6.0.0', require: false
   gem 'rubocop-rails', '~> 2.5.1', require: false
   gem 'spring', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,8 +179,6 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
-    mry (0.78.0.0)
-      rubocop (>= 0.41.0)
     msgpack (1.3.3)
     multi_json (1.14.1)
     multipart-post (2.1.1)
@@ -364,7 +362,6 @@ DEPENDENCIES
   jb (~> 0.7.1)
   letter_opener (~> 1.7.0)
   listen (>= 3.0.5, < 3.3)
-  mry
   pagy (~> 3.7)
   pg (~> 1.2.3)
   puma (~> 4.3)
@@ -388,4 +385,4 @@ RUBY VERSION
    ruby 2.6.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.0.2

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ You can run the unit tests with `rspec` or `rspec` followed by a specific test f
 With `rake linters` you can run the code analysis tool, you can omit rules with:
 
 - [Rubocop](https://github.com/bbatsov/rubocop/blob/master/config/default.yml) Edit `.rubocop.yml`
+
+  When you update RuboCop version, sometimes you need to change `.rubocop.yml`. If you use [mry](https://github.com/pocke/mry), you can update `.rubocop.yml` to latest version automatically.
+
 - [Reek](https://github.com/troessner/reek#configuration-file) Edit `config.reek`
 
 Pass the `-a` option to auto-fix (only for some linterns).


### PR DESCRIPTION
#### Description:

* Add reference to `mry` gem in `README.md`
* Update `rubocop.yml` file
* Fix rubocop errors
---

#### :heavy_check_mark:Tasks:

* Run `rubocop -a` in your console and check that there aren't any errors.
---
