### PR TITLE
Improve API error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ pagy, records = pagy(User.all)
 pagy_headers_merge(pagy)
 render json: records
 ```
+The frontend needs to pass the query param `page` to retrieve a specific page.
 
 #### Nilify Blanks
 The [nilify_blanks](https://github.com/rubiety/nilify_blanks) line on `ApplicationRecord` adds a before validation callback to substitute all blank string fields to be `nil` instead, to ensure no blank fields are saved on the db.

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -2,14 +2,17 @@ module ExceptionHandler
   extend ActiveSupport::Concern
 
   included do
-    rescue_from StandardError, with: :render_standard_error
+    rescue_from StandardError, with: :handle_standard_error
     rescue_from ActionController::ParameterMissing, with: :render_parameter_missing
     rescue_from ActiveRecord::RecordNotFound, with: :render_record_not_found
     rescue_from ActionView::Template::Error, with: :handle_template_error
-    rescue_from ActiveRecord::RecordInvalid, with: :handle_record_invalid
+    rescue_from ActiveRecord::RecordInvalid, with: :render_record_invalid
+    rescue_from Pagy::OverflowError, with: :render_page_not_found
 
     before_action :set_raven_context
   end
+
+  private
 
   def render_errors(error_messages, status)
     error_messages = Array(error_messages)
@@ -20,16 +23,30 @@ module ExceptionHandler
     render json: { attributes_errors: error_messages }, status: :bad_request
   end
 
-  def render_standard_error(exception)
+  def render_parameter_missing(exception)
+    render_errors(I18n.t('errors.missing_param', param: exception.param.to_s), :bad_request)
+  end
+
+  def render_record_not_found(exception)
+    render_errors(I18n.t('errors.record_not_found', exception.model), :not_found)
+  end
+
+  def render_record_invalid(exception)
+    errors = exception.record.errors.messages
+    render_attributes_errors(errors)
+  end
+
+  def render_page_not_found
+    render json: { errors: I18n.t('errors.page_not_found') }, status: :bad_request
+  end
+
+  def handle_standard_error(exception)
     raise exception if Rails.env.test?
 
     logger.error(exception)
+    Raven.capture_exception(exception)
 
     render_errors(I18n.t('errors.server'), :internal_server_error)
-  end
-
-  def render_parameter_missing(exception)
-    render_errors(I18n.t('errors.missing_param', param: exception.param.to_s), :bad_request)
   end
 
   def handle_template_error(exception)
@@ -37,17 +54,8 @@ module ExceptionHandler
     if cause.is_a?(ActiveRecord::RecordNotFound)
       render_record_not_found(cause)
     else
-      render_standard_error(cause)
+      handle_standard_error(cause)
     end
-  end
-
-  def render_record_not_found(exception)
-    render_errors(I18n.t('errors.record_not_found', exception.model), :not_found)
-  end
-
-  def handle_record_invalid(exception)
-    errors = exception.record.errors.messages
-    render_attributes_errors(errors)
   end
 
   def set_raven_context

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
     record_not_found: '%{model} not found'
     missing_param: 'The following param is missing or the value is empty: %{param}'
     invalid_content_type: 'Invalid content type header'
+    page_not_found: 'The requested page does not exist'
     authentication:
       invalid_credentials: 'The credentials are not valid'
       invalid_token: 'The token is not valid'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -18,9 +18,11 @@ es:
     record_not_found: '%{model} no encontrado'
     missing_param: 'Falta el siguiente parámetro o el valor está vacío: %{param}'
     invalid_content_type: 'Content-Type inválido en el encabezado'
+    page_not_found: 'La página solicitada no existe'
     authentication:
       invalid_credentials: 'Las credenciales no son válidas'
       invalid_token: 'El token no es válido'
+      invalid_password_check: 'La contraseña actual no es válida'
   emails:
     reset_password:
       recover_account: 'Recuperar cuenta'


### PR DESCRIPTION
# Improve API error logging

#### :heavy_check_mark:Tasks:

* Adds missing translations for error rendering
* Adds in the README instructions on how the frontend should pass the pagination page param
* Rescues from page overload (when frontend requests a page that is > than the last page) and renders a message
* Sends all 500 server errors to sentry!

---

@loopstudio/ruby-devs
