### PR TITLE
fix reset password error messages

### DIFF
--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -15,7 +15,7 @@ module Api
 
         head(:no_content) && return if @resource.reset_password_period_valid?
 
-        render_token_expired
+        render_token_invalid
       end
 
       def update
@@ -26,8 +26,8 @@ module Api
           response.headers.merge!(@resource.create_new_auth_token)
           render_update_success
         else
-          token_error = errors[:reset_password_token].any?
-          token_error ? render_token_expired : render_attributes_errors(errors)
+          token_error = errors.messages.key?(:reset_password_token)
+          token_error ? render_token_invalid : render_attributes_errors(errors)
         end
       end
 
@@ -41,8 +41,8 @@ module Api
         render('api/v1/users/show', locals: { user: @resource })
       end
 
-      def render_token_expired
-        render_errors([I18n.t('errors.messages.reset_password_token_expired')], :bad_request)
+      def render_token_invalid
+        render_errors([I18n.t('errors.invalid_reset_password_token')], :bad_request)
       end
 
       def update_params

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
     missing_param: 'The following param is missing or the value is empty: %{param}'
     invalid_content_type: 'Invalid content type header'
     page_not_found: 'The requested page does not exist'
+    invalid_reset_password_token: 'the reset password token is invalid'
     authentication:
       invalid_credentials: 'The credentials are not valid'
       invalid_token: 'The token is not valid'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -21,6 +21,7 @@ es:
     missing_param: 'Falta el siguiente parámetro o el valor está vacío: %{param}'
     invalid_content_type: 'Content-Type inválido en el encabezado'
     page_not_found: 'La página solicitada no existe'
+    reset_password_token_invalid: 'el token para restablecer la contraseña no es válido'
     authentication:
       invalid_credentials: 'Las credenciales no son válidas'
       invalid_token: 'El token no es válido'

--- a/spec/requests/api/v1/passwords/edit_spec.rb
+++ b/spec/requests/api/v1/passwords/edit_spec.rb
@@ -42,10 +42,10 @@ describe 'GET api/v1/users/password/edit', type: :request do
       expect(response).to have_http_status(:bad_request)
     end
 
-    it 'renders an error message explaining the code expired' do
+    it 'renders an error message explaining the code is invalid' do
       get_request
 
-      expect(json[:errors]).to include(I18n.t('errors.messages.reset_password_token_expired'))
+      expect(json[:errors]).to include(I18n.t('errors.invalid_reset_password_token'))
     end
   end
 

--- a/spec/requests/api/v1/passwords/update_spec.rb
+++ b/spec/requests/api/v1/passwords/update_spec.rb
@@ -72,6 +72,12 @@ describe 'PUT api/v1/users/password/', type: :request do
         expect(response).to have_http_status(:bad_request)
       end
 
+      specify do
+        put_request
+
+        expect(json[:attributes_errors]).not_to have_key('reset_password_token')
+      end
+
       it 'does not change the user password' do
         expect {
           put_request


### PR DESCRIPTION
#### Description:

The reset_password_token_expired error was called when the token expired and when user entered a bad token. It wasn't specified on the languages files also so I defined an invalid_reset_password_token error instead.

On the update method of the password controller it was executing `errors[:reset_password_token].any?`, for some reason, this line was adding `reset_password_token: []` to error.messages where it wasn't before. Instead of asking for the value inside the key, now I'm asking if the key is present to prevent the described before to happen.

---

#### :pushpin: Notes:

* Not sure if the test added is enough

---

#### :heavy_check_mark:Tasks:

* Add invalid_reset_password_token error
* Fix update password error response message
* Add tests

---

@loopstudio/ruby-devs
