### PR TITLE
change password reset token error

### DIFF
--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -11,9 +11,7 @@ module Api
       def edit
         @resource = resource_class.with_reset_password_token(resource_params[:reset_password_token])
 
-        head(:not_found) && return unless @resource
-
-        head(:no_content) && return if @resource.reset_password_period_valid?
+        head(:no_content) && return if @resource&.reset_password_period_valid?
 
         render_token_invalid
       end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -37,7 +37,7 @@ module ExceptionHandler
   end
 
   def render_page_not_found
-    render json: { errors: I18n.t('errors.page_not_found') }, status: :bad_request
+    render_errors(I18n.t('errors.page_not_found'), :bad_request)
   end
 
   def handle_standard_error(exception)

--- a/spec/requests/api/v1/passwords/edit_spec.rb
+++ b/spec/requests/api/v1/passwords/edit_spec.rb
@@ -24,18 +24,7 @@ describe 'GET api/v1/users/password/edit', type: :request do
     end
   end
 
-  context 'with an expired token' do
-    let(:params) do
-      {
-        reset_password_token: password_token
-      }
-    end
-
-    before do
-      sent_at = user.reset_password_sent_at - Devise.reset_password_within - 1.second
-      user.update!(reset_password_sent_at: sent_at)
-    end
-
+  shared_examples 'returns invalid token error' do
     specify do
       get_request
 
@@ -49,6 +38,21 @@ describe 'GET api/v1/users/password/edit', type: :request do
     end
   end
 
+  context 'with an expired token' do
+    let(:params) do
+      {
+        reset_password_token: password_token
+      }
+    end
+
+    before do
+      sent_at = user.reset_password_sent_at - Devise.reset_password_within - 1.second
+      user.update!(reset_password_sent_at: sent_at)
+    end
+
+    include_examples 'returns invalid token error'
+  end
+
   context 'with an invalid token' do
     let(:params) do
       {
@@ -56,10 +60,6 @@ describe 'GET api/v1/users/password/edit', type: :request do
       }
     end
 
-    specify do
-      get_request
-
-      expect(response).to have_http_status(:not_found)
-    end
+    include_examples 'returns invalid token error'
   end
 end


### PR DESCRIPTION

#### Description:

When the user entered an invalid password reset token the response was returning a 404 error, now it returns an invalid token error

---

#### :heavy_check_mark:Tasks:

* Change the invalid reset password token error
* Add tests

---

@loopstudio/ruby-devs
