### PR TITLE
Require rails_helper from '.rspec'

### DIFF
--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -17,8 +17,6 @@
 #  index_admin_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
 
-require 'rails_helper'
-
 RSpec.describe AdminUser, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:email) }

--- a/spec/requests/api/v1/passwords/create_spec.rb
+++ b/spec/requests/api/v1/passwords/create_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'POST /api/v1/users/password', type: :request do
   subject(:post_request) do
     post user_password_path, params: params, as: :json

--- a/spec/requests/api/v1/passwords/edit_spec.rb
+++ b/spec/requests/api/v1/passwords/edit_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'addressable/uri'
 
 describe 'GET api/v1/users/password/edit', type: :request do

--- a/spec/requests/api/v1/passwords/update_spec.rb
+++ b/spec/requests/api/v1/passwords/update_spec.rb
@@ -1,4 +1,3 @@
-require 'rails_helper'
 require 'addressable/uri'
 
 describe 'PUT api/v1/users/password/', { type: :request } do

--- a/spec/requests/api/v1/sessions/create_spec.rb
+++ b/spec/requests/api/v1/sessions/create_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'POST /api/v1/users/sign_in', type: :request do
   subject(:post_request) do
     post user_session_path, params: params, as: :json

--- a/spec/requests/api/v1/sessions/destroy_spec.rb
+++ b/spec/requests/api/v1/sessions/destroy_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'DELETE /api/v1/users/sign_out', type: :request do
   let(:user) { create(:user) }
 

--- a/spec/requests/api/v1/token_validations/validate_token_spec.rb
+++ b/spec/requests/api/v1/token_validations/validate_token_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'GET /api/v1/users/validate_token', type: :request do
   let(:user) { create(:user) }
 

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'POST /api/v1/users', type: :request do
   subject(:post_request) do
     post api_v1_users_path, params: params, as: :json

--- a/spec/requests/api/v1/users/show_spec.rb
+++ b/spec/requests/api/v1/users/show_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'GET /api/v1/user', type: :request do
   let(:user) { create(:user) }
 

--- a/spec/requests/api/v1/users/update_spec.rb
+++ b/spec/requests/api/v1/users/update_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'PUT /api/v1/user', type: :request do
   let(:user) { create(:user) }
 


### PR DESCRIPTION
#### :link: Board reference:

* [Require rails_helper from '.rspec'](https://loopstudio.atlassian.net/jira/software/projects/API/boards/12?selectedIssue=API-85)

---

#### Description:

Require rails_helper from '.rspec' so we don’t have to add the `require 'rails_helper'`to each test file

---

@loopstudio/ruby-devs
