### PR TITLE
run linters on all files

### DIFF
--- a/lib/tasks/linters.rake
+++ b/lib/tasks/linters.rake
@@ -6,12 +6,6 @@ task :linters do
     opts.on('-a') { |autofix| options[:autofix] = autofix }
   }.parse!
 
-  sh 'git fetch origin'
-
-  files_diff = `git diff-tree -r --no-commit-id --name-only HEAD origin/master | xargs`
-
-  if files_diff.present?
-    sh "bundle exec rubocop --force-exclusion #{'-a' if options[:autofix]} #{files_diff}"
-    sh "bundle exec reek --force-exclusion -c .reek.yml #{files_diff}"
-  end
+  sh "bundle exec rubocop --force-exclusion #{'-a' if options[:autofix]}"
+  sh 'bundle exec reek --force-exclusion -c .reek.yml'
 end


### PR DESCRIPTION
#### :link: Board reference:

* [Include all files while running linters](https://loopstudio.atlassian.net/jira/software/projects/API/boards/12?selectedIssue=API-105)

---

#### Description:

Linters where running only on the diff files, in certain cases this make the checks to fail. This pr make the linters run on the whole app as discussed on the tech council.

---

#### :pushpin: Notes:

* This changes would make effect both locally and on github actions


---

@loopstudio/ruby-devs
