### PR TITLE
chore: Perform env var fetching at initialization time

### DIFF
--- a/.github/workflows/tests_and_linters.yml
+++ b/.github/workflows/tests_and_linters.yml
@@ -21,6 +21,12 @@ jobs:
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
+    env:
+      PGHOST: localhost
+      PGUSER: postgres
+      RAILS_ENV: test
+      DEFAULT_FROM_EMAIL_ADDRESS: test@loopstudio.dev
+
     steps:
     - uses: actions/checkout@v2
 
@@ -34,10 +40,6 @@ jobs:
         sudo apt-get -yqq install libpq-dev
 
     - name: Build App
-      env:
-        PGHOST: localhost
-        PGUSER: postgres
-        RAILS_ENV: test
       run: |
         gem install bundler
         bundle config path vendor/bundle
@@ -45,13 +47,7 @@ jobs:
         bin/rails db:setup
 
     - name: Run Linters
-      env:
-        RAILS_ENV: test
       run: bundle exec rake linters
 
     - name: Run Tests
-      env:
-        PGHOST: localhost
-        PGUSER: postgres
-        RAILS_ENV: test
       run: bundle exec rspec

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,3 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV['DEFAULT_FROM_EMAIL_ADDRESS'], reply_to: ENV['DEFAULT_FROM_EMAIL_ADDRESS']
   layout 'mailer'
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,8 @@ module RailsApiBoilerplate
 
     config.action_mailer.default_url_options = { host: ENV['SERVER_URL'] }
     config.action_mailer.default_options = {
-      from: ENV['DEFAULT_FROM_EMAIL_ADDRESS']
+      from: ENV.fetch('DEFAULT_FROM_EMAIL_ADDRESS'),
+      reply_to: ENV.fetch('DEFAULT_FROM_EMAIL_ADDRESS')
     }
 
     config.generators do |gen|


### PR DESCRIPTION
Avoid runtime errors due to misconfiguration and instead catch them at boot time