### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aperezcristina @elestu @mconiglio @diebas @fdecono @Stefano-loop
+* @loopstudio/ruby-devs


### PR DESCRIPTION
Use the team to avoid having to manually add/remove members